### PR TITLE
RSPY-564 - Set maxItemsPerPage=100 for CADIP/AUXIP STAC browser instances

### DIFF
--- a/apps/stac-browser-auxip/values.yaml
+++ b/apps/stac-browser-auxip/values.yaml
@@ -38,6 +38,8 @@ app:
   SB_socialSharing: "email,bsky,mastodon"
   # -- URL of the STAC catalog
   SB_catalogUrl: https://{{ platform_domain_name }}/auxip/
+  # -- maxItemsPerPage - see https://github.com/radiantearth/stac-browser/pull/563
+  SB_maxItemsPerPage: 100
 
 # -- Pod affinity
 affinity:

--- a/apps/stac-browser-cadip/values.yaml
+++ b/apps/stac-browser-cadip/values.yaml
@@ -38,6 +38,8 @@ app:
   SB_socialSharing: "email,bsky,mastodon"
   # -- URL of the STAC catalog
   SB_catalogUrl: https://{{ platform_domain_name }}/cadip/
+  # -- maxItemsPerPage - see https://github.com/radiantearth/stac-browser/pull/563
+  SB_maxItemsPerPage: 100
 
 # -- Pod affinity
 affinity:


### PR DESCRIPTION
See https://github.com/radiantearth/stac-browser/pull/563
See https://github.com/RS-PYTHON/rs-helm/pull/146