### PR TITLE
RSPY-843 - test real deployment in ci/cd

### DIFF
--- a/.github/common/resources/configure-minikube-deployment.sh
+++ b/.github/common/resources/configure-minikube-deployment.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright 2025 CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+APPS=rs-server-deployment/apps
+
+# Lower the CPU/memory requests
+# Minimum memory for postgresql must be > shared_buffers, which is 1/4 of the total ram
+sed -i -e 's!instances: 3!instances: 1!g' -e 's!cpu: "1"!cpu: "0.1"!g' -e 's!memory: "2G"!memory: "256M"!g' -e 's!memory: "1024M"!memory: "100M"!g' "${APPS}/01-eo-cnpgstac/values.yaml"
+sed -i -e 's!cpu: "100m"!cpu: "1m"!g' -e 's!ram: "256Mi"!ram: "10Mi"!g'\
+  "${APPS}/mockup-prip-s1a/values.yaml"\
+  "${APPS}/mockup-prip-s2b/values.yaml"\
+  "${APPS}/mockup-processor-dpr/values.yaml"\
+  "${APPS}/mockup-station-adgs/values.yaml"\
+  "${APPS}/mockup-station-cadip-cadip/values.yaml"\
+  "${APPS}/mockup-station-cadip-mti/values.yaml"\
+  "${APPS}/mockup-station-cadip-sgs/values.yaml"\
+  "${APPS}/mockup-station-lta/values.yaml"
+sed -i -e 's!cpu: "100m"!cpu: "10m"!g' -e 's!ram: "256Mi"!ram: "32Mi"!g'\
+  "${APPS}/rs-dpr-service/values.yaml"\
+  "${APPS}/rs-server-adgs/values.yaml"\
+  "${APPS}/rs-server-cadip/values.yaml"\
+  "${APPS}/rs-server-catalog/values.yaml"\
+  "${APPS}/rs-server-frontend/values.yaml"\
+  "${APPS}/rs-server-prip/values.yaml"\
+  "${APPS}/rs-server-staging/values.yaml"

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -29,56 +29,139 @@ jobs:
   test-deploy:
     if: github.actor != 'dependabot[bot]' # ignore pull requests by github bot
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Deployment with monitoring"
+            deploy_monitoring: true
+# TODO enable this in RSPY-836
+#          - name: "Deployment without monitoring"
+#            deploy_monitoring: false
+    name: ${{ matrix.name }}
     steps:
-      - name: Checkout repository
+      - name: Get current branch name
+        id: vars
+        run: echo "branch_name=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+      - name: Check if branch exists in rs-infra-core
+        id: check_branch
+        run: |
+          BRANCH=${{ steps.vars.outputs.branch_name }}
+          if git ls-remote --heads https://github.com/RS-PYTHON/rs-infra-core.git $BRANCH | grep -q $BRANCH; then
+            echo "branch_to_use=$BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "branch_to_use=" >> $GITHUB_OUTPUT  # Leave empty to use default
+          fi
+        shell: bash
+      - name: Checkout infra-core repository
         uses: actions/checkout@v4
         with:
           repository: RS-PYTHON/rs-infra-core
-          submodules: recursive
+          ref: ${{ steps.check_branch.outputs.branch_to_use }}
+      - name: Checkout infra-monitoring repository
+        uses: actions/checkout@v4
+        if: ${{ matrix.deploy_monitoring }}
+        with:
+          path: rs-infra-monitoring
+          repository: RS-PYTHON/rs-infra-monitoring
+      - name: Checkout workflow-env repository
+        uses: actions/checkout@v4
+        with:
+          path: rs-workflow-env
+          repository: RS-PYTHON/rs-workflow-env
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           path: rs-server-deployment
           ref: ${{ github.ref }}
-      - name: Install requirements
+      - name: Cache Miniforge and Conda env
+        id: cache-conda
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/miniforge3
+            /usr/share/miniconda
+          key: conda-${{ runner.os }}-${{ hashFiles('.github/common/resources/install-requirements.sh') }}
+          restore-keys: |
+            conda-${{ runner.os }}-
+      - name: Aggressive cleanup
         run: |
-          # Install miniforge
-          mkdir -p ~/miniforge3
-          wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge3/miniforge.sh
-          bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-          rm -f ~/miniforge3/miniforge.sh
-
-          # Init conda
-          ~/miniforge3/bin/conda init bash
-
-          # Create conda env with python
-          conda create -y -n rspy python=3.11
-
-          # Install Ansible, Terraform, Openstackclient
-          conda run -n rspy conda install -y -c conda-forge ansible terraform python-openstackclient passlib boto3 kubernetes-helm kubernetes-client python-kubernetes
-          
-          conda run -n rspy ansible-galaxy collection install openstack.cloud amazon.aws kubernetes.core
-          ln -s /usr/share/miniconda/envs/rspy/bin/kubectl /usr/local/bin/kubectl
+          # Cleanup disk space (level between 0 and 14, more cleaning takes more time)
+          .github/common/resources/aggressive-cleanup.sh 2
+        shell: bash
+      - name: Install requirements (if cache missed)
+        if: steps.cache-conda.outputs.cache-hit != 'true'
+        run: |
+          .github/common/resources/install-requirements.sh
         shell: bash
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
         with:
-          start-args: '--profile cluster.local'
+          addons: 'metallb,metrics-server'
+          cpus: 4
           memory: 8000m
+          start-args: '--disk-size=32g'
+      - name: "Configure cluster labels, IP and DNS (host + CoreDNS)"
+        run: |
+          if [ "${{ matrix.deploy_monitoring }}" = "true" ]; then
+            .github/common/resources/configure-cluster.sh "node-role.kubernetes.io/infra= node-role.kubernetes.io/rs_env= node-role.kubernetes.io/rs_server= node-role.kubernetes.io/access_csc=" "apikeymanager iam kube monitoring oauth2-proxy processing stac-browser-auxip stac-browser-cadip stac-browser-catalog stac-browser-prip"
+          else
+            .github/common/resources/configure-cluster.sh "node-role.kubernetes.io/infra= node-role.kubernetes.io/rs_env= node-role.kubernetes.io/rs_server= node-role.kubernetes.io/access_csc=" "apikeymanager iam kube oauth2-proxy processing stac-browser-auxip stac-browser-cadip stac-browser-catalog stac-browser-prip"
+          fi
+        shell: bash
+      - name: Deploy minio
+        run: |
+          # Minio for cloudnative pg - https://github.com/minio/minio/tree/master/helm/minio#installing-the-chart-toy-setup
+          helm repo add minio https://charts.min.io/
+          helm repo update minio
+          if [ "${{ matrix.deploy_monitoring }}" = "true" ]; then
+            helm install minio minio/minio --namespace minio --set mode=standalone --set replicas=1 --set persistence.enabled=false --set resources.requests.memory=128Mi --set rootUser=s3_access_key,rootPassword=s3_secret_key --set buckets[0].name=rs-cluster-psql,buckets[1].name=rs-cluster-velero,buckets[2].name=rs-cluster-loki-chunks,buckets[3].name=rs-cluster-loki-ruler,buckets[4].name=rs-cluster-tempo --create-namespace --wait
+          else
+            helm install minio minio/minio --namespace minio --set mode=standalone --set replicas=1 --set persistence.enabled=false --set resources.requests.memory=128Mi --set rootUser=s3_access_key,rootPassword=s3_secret_key --set buckets[0].name=rs-cluster-psql,buckets[1].name=rs-cluster-velero --create-namespace --wait
+          fi
       - name: Generate inventory
         run: |
-          cp -rfp inventory/sample inventory/mycluster
-          mv inventory/mycluster/.env.template inventory/mycluster/.env
-          mv inventory/mycluster/openrc.sh.template inventory/mycluster/openrc.sh
-          sed -i 's!<changeme_with_full_path>/miniforge3/envs/rspy!/usr/share/miniconda/envs/rspy!g' inventory/mycluster/hosts.yaml
+          .github/common/resources/configure-inventory.sh
+          # --- Generate inventory
           conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook registry.yaml -i inventory/mycluster/hosts.yaml -e ci_mode=true
           conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook generate_inventory.yaml -i inventory/mycluster/hosts.yaml
         shell: bash
-      - name: Deploy the core apps (check)
+      - name: Deploy the core apps (for real)
         run: |
-          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook --check apps.yaml -i inventory/mycluster/hosts.yaml -e private_registry=true
+          # --- Use local cluster issuer instead of Let's Encrypt
+          if [ "${{ matrix.deploy_monitoring }}" = "true" ]; then
+            .github/common/resources/configure-local-ca.sh apikeymanager:processing iam:iam kube:default monitoring:monitoring processing:processing oauth2-proxy:iam stac-browser-auxip:processing stac-browser-cadip:processing stac-browser-catalog:processing stac-browser-prip:processing
+          else
+            .github/common/resources/configure-local-ca.sh apikeymanager:processing iam:iam kube:default processing:processing oauth2-proxy:iam stac-browser-auxip:processing stac-browser-cadip:processing stac-browser-catalog:processing stac-browser-prip:processing
+          fi
+          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook apps.yaml -i inventory/mycluster/hosts.yaml
+        shell: bash
+      - name: Deploy the monitoring apps (for real)
+        if: ${{ matrix.deploy_monitoring }}
+        run: |
+          ./rs-infra-monitoring/.github/common/resources/configure-minikube-deployment.sh
+          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook apps.yaml -i inventory/mycluster/hosts.yaml -e '{"package_paths": ["./rs-infra-monitoring/apps/"]}'
+        shell: bash
+      - name: Deploy the required workflow-env apps (for real)
+        run: |
+          # rs-server requires apikeymanager, dask
+          for app in apikeymanager-db apikeymanager dask-gateway ; do
+            echo Installing $app...
+            conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook apps.yaml -i inventory/mycluster/hosts.yaml  -e '{"package_paths": ["./rs-workflow-env/apps/"], "app": "'$app'"}'
+          done
         shell: bash
       - name: Deploy the rs-server apps (check)
         run: |
           conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook --check apps.yaml -i inventory/mycluster/hosts.yaml -e '{"package_paths": ["./rs-server-deployment/apps/"]}' -e private_registry=true
+        shell: bash
+      - name: Deploy the rs-server apps (for real)
+        run: |
+          sed -i 's!debug: false!debug: true!g' roles/app-installer/defaults/main.yaml
+          ./rs-server-deployment/.github/common/resources/configure-minikube-deployment.sh
+          conda run -n rspy --no-capture-output env PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=1 ansible-playbook apps.yaml -i inventory/mycluster/hosts.yaml -e '{"package_paths": ["./rs-server-deployment/apps/"]}'
+        shell: bash
+      - name: 🩺 Kubernetes failure diagnostics
+        if: failure()
+        run: |
+          .github/common/resources/minikube-diagnostics.sh
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -12,7 +12,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.29 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+    rev: v0.1.30 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
     hooks:
     -   id: terraform-fmt
       # -   id: terraform-validate

--- a/apps/01-dask-cluster-staging/configmap.yaml
+++ b/apps/01-dask-cluster-staging/configmap.yaml
@@ -203,4 +203,3 @@ data:
     while True:
         print(f"[heartbeat] workers={current_worker_count(client)} target={TARGET_WORKERS}")
         time.sleep(30)
-

--- a/apps/01-dask-cluster-staging/deployment.yaml
+++ b/apps/01-dask-cluster-staging/deployment.yaml
@@ -46,4 +46,3 @@ spec:
       - configMap:
           name: dask-cluster-script
         name: script-volume
-

--- a/apps/01-dask-cluster-staging/kustomization.yaml
+++ b/apps/01-dask-cluster-staging/kustomization.yaml
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
-
 namespace: dask-gateway
-
 resources:
-  - configmap.yaml
-  - deployment.yaml
-  - secret.yaml
+- configmap.yaml
+- deployment.yaml
+- secret.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/01-eo-cnpgstac/kustomization.yaml
+++ b/apps/01-eo-cnpgstac/kustomization.yaml
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: database
 
 helmCharts:
 - name: eo-cnpgstac
+  releaseName: '{{ app_name }}'
   repo: oci://643vlk6z.gra7.container-registry.ovh.net/public/
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-alpha
   valuesFile: values.yaml
+  version: 1.0.0-alpha
 
 resources:
-  - grafanadatasource.yaml
-  - podmonitor.yaml
-  - scheduledbackup.yaml
-  - secret.yaml
+- grafanadatasource.yaml
+- podmonitor.yaml
+- scheduledbackup.yaml
+- secret.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/01-eo-cnpgstac/values.yaml
+++ b/apps/01-eo-cnpgstac/values.yaml
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  wait-for-deployment: Ready
-
 ## @section CloudNative PostGIS parameters
 cnpgstac:
   ## @param cnpgstac.enabled Enabled CloudNative PostGIS
@@ -22,6 +19,9 @@ cnpgstac:
 
   ## @param cnpgstac.clusterName Name of the cnpgstac cluster
   clusterName: cnpgstac
+
+  clusterLabels:
+    wait-for-deployment: Ready
 
   ## Define postgres user password
   ## ref: https://cloudnative-pg.io/documentation/current/security/#postgresql
@@ -88,7 +88,7 @@ cnpgstac:
 
     ## Enable readonly mode in pgstac
     ## If true, usage of titiler-pgstac is limited
-    ## ref: https://github.com/stac-utils/pgstac/pull/215 and https://github.com/stac-utils/pgstac/issues/296 
+    ## ref: https://github.com/stac-utils/pgstac/pull/215 and https://github.com/stac-utils/pgstac/issues/296
     enableReadOnly: true
 
   ## CloudNative PostGIS resource requests and limits

--- a/apps/01-pi-db/kustomization.yaml
+++ b/apps/01-pi-db/kustomization.yaml
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 
 namespace: database
 
 resources:
-  - database.yaml
-  - grafanadatasource.yaml
+- database.yaml
+- grafanadatasource.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/01-pygeoapi-db/kustomization.yaml
+++ b/apps/01-pygeoapi-db/kustomization.yaml
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 
 namespace: database
 
 resources:
-  - database.yaml
-  - grafanadatasource.yaml
+- database.yaml
+- grafanadatasource.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/01-rs-catalog-staging-configmap/kustomization.yaml
+++ b/apps/01-rs-catalog-staging-configmap/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-catalog-staging-configmap
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/01-rs-server-station-secrets/kustomization.yaml
+++ b/apps/01-rs-server-station-secrets/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-server-station-secrets
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-prip-s1a/kustomization.yaml
+++ b/apps/mockup-prip-s1a/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-station-prip
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-prip-s1a/values.yaml
+++ b/apps/mockup-prip-s1a/values.yaml
@@ -21,6 +21,18 @@ app:
   # -- Path inside the bucket to the data
   bucketPath: {{ rs_station_mockup.prip.s1a.bucketPath}}
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/mockup-prip-s2b/kustomization.yaml
+++ b/apps/mockup-prip-s2b/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-station-prip
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-prip-s2b/values.yaml
+++ b/apps/mockup-prip-s2b/values.yaml
@@ -21,6 +21,18 @@ app:
   # -- Path inside the bucket to the data
   bucketPath: {{ rs_station_mockup.prip.s2b.bucketPath}}
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/mockup-processor-dpr/kustomization.yaml
+++ b/apps/mockup-processor-dpr/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-processor-dpr
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-processor-dpr/values.yaml
+++ b/apps/mockup-processor-dpr/values.yaml
@@ -26,6 +26,18 @@ obs:
     # -- Secret Key to authenticate with the object storage service
     sk: {{ s3.secret_key }}
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/mockup-station-adgs/kustomization.yaml
+++ b/apps/mockup-station-adgs/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-station-adgs
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-station-adgs/values.yaml
+++ b/apps/mockup-station-adgs/values.yaml
@@ -21,6 +21,18 @@ app:
   # -- Path inside the bucket to the data
   bucketPath: {{ rs_station_mockup.adgs.adgs.bucketPath}}
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/mockup-station-cadip-cadip/kustomization.yaml
+++ b/apps/mockup-station-cadip-cadip/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-station-cadip
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-station-cadip-cadip/values.yaml
+++ b/apps/mockup-station-cadip-cadip/values.yaml
@@ -21,6 +21,18 @@ app:
   # -- Path inside the bucket to the data
   bucketPath: {{ rs_station_mockup.cadip.cadip.bucketPath}}
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/mockup-station-cadip-mti/kustomization.yaml
+++ b/apps/mockup-station-cadip-mti/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-station-cadip
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-station-cadip-mti/values.yaml
+++ b/apps/mockup-station-cadip-mti/values.yaml
@@ -21,6 +21,18 @@ app:
   # -- Path inside the bucket to the data
   bucketPath: {{ rs_station_mockup.cadip.mti.bucketPath}}
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/mockup-station-cadip-sgs/kustomization.yaml
+++ b/apps/mockup-station-cadip-sgs/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-station-cadip
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-station-cadip-sgs/values.yaml
+++ b/apps/mockup-station-cadip-sgs/values.yaml
@@ -21,6 +21,18 @@ app:
   # -- Path inside the bucket to the data
   bucketPath: {{ rs_station_mockup.cadip.sgs.bucketPath}}
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/mockup-station-lta/kustomization.yaml
+++ b/apps/mockup-station-lta/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: mockup-station-lta
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/mockup-station-lta/values.yaml
+++ b/apps/mockup-station-lta/values.yaml
@@ -15,6 +15,18 @@
 # -- Namespace for the deployment
 namespace: processing
 
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
+
 # -- Pod affinity
 affinity:
   nodeAffinity:

--- a/apps/rs-dpr-service/kustomization.yaml
+++ b/apps/rs-dpr-service/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-dpr-service
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/rs-dpr-service/values.yaml
+++ b/apps/rs-dpr-service/values.yaml
@@ -155,7 +155,7 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name
   host: {{ platform_domain_name }}
   # -- Ingress path for the application

--- a/apps/rs-server-adgs/kustomization.yaml
+++ b/apps/rs-server-adgs/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-server-adgs
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/rs-server-adgs/values.yaml
+++ b/apps/rs-server-adgs/values.yaml
@@ -76,13 +76,25 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name
   host: {{ rs_server.full_domain }}
   # -- Ingress path
   path:
     - /adgs
     - /auxip
+
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
 
 # -- Pod affinity
 affinity:

--- a/apps/rs-server-cadip/kustomization.yaml
+++ b/apps/rs-server-cadip/kustomization.yaml
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-server-cadip
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
 
 
 resources:
-  - grafanadatasource.yaml
+- grafanadatasource.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/rs-server-cadip/values.yaml
+++ b/apps/rs-server-cadip/values.yaml
@@ -71,11 +71,23 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name
   host: {{ rs_server.full_domain }}
   # -- Ingress path
   path: /cadip
+
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
 
 # -- Pod affinity
 affinity:

--- a/apps/rs-server-catalog/kustomization.yaml
+++ b/apps/rs-server-catalog/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-server-catalog
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/rs-server-catalog/values.yaml
+++ b/apps/rs-server-catalog/values.yaml
@@ -80,13 +80,25 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name
   host: {{ rs_server.full_domain }}
   # -- Ingress path
   path:
     - /catalog
     - /auth
+
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
 
 # -- Pod affinity
 affinity:

--- a/apps/rs-server-frontend/kustomization.yaml
+++ b/apps/rs-server-frontend/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-server-frontend
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/rs-server-frontend/values.yaml
+++ b/apps/rs-server-frontend/values.yaml
@@ -32,11 +32,23 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name
   host: {{ rs_server.full_domain }}
   # -- Ingress path for the application. Must be the same value as app.docsUrl.
   path: /docs
+
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
 
 # -- Pod affinity
 affinity:

--- a/apps/rs-server-prip/kustomization.yaml
+++ b/apps/rs-server-prip/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-server-prip
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/rs-server-prip/values.yaml
+++ b/apps/rs-server-prip/values.yaml
@@ -75,12 +75,24 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name
   host: {{ rs_server.full_domain }}
   # -- Ingress path
   path:
     - /prip
+
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
 
 # -- Pod affinity
 affinity:

--- a/apps/rs-server-staging/kustomization.yaml
+++ b/apps/rs-server-staging/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: rs-server-staging
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/rs-server-staging/values.yaml
+++ b/apps/rs-server-staging/values.yaml
@@ -49,13 +49,13 @@ app:
       type: s3
 
   # -- Bucket configuration to use to monitor the lifespan and name of data buckets
-  # Use an external configuration through an external configmap with the value "externalCatalogBucketConfigMapName"
+  # Use an external configuration through an external configmap with the value "externalStagingBucketConfigMapName"
   # OR
   # Set your own configuration in the value expirationBucketCsv
   bucketConfig:
     # -- Set to true to use an external configmap for the configuration instead of the one set in expirationBucketCsv
     useExternalStagingBucketConfigMap: true
-    # -- Name of the external configmap to use. Used only if useExternalCatalogBucketConfigMap is true
+    # -- Name of the external configmap to use. Used only if useExternalStagingBucketConfigMap is true
     externalStagingBucketConfigMapName: "rs-catalog-staging-configmap"
 
 dask:
@@ -112,13 +112,25 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name
   host: {{ rs_server.full_domain }}
   # -- Ingress path for the application
   path:
     - /processes
     - /jobs
+
+resources:
+  request:
+    # -- Pod memory request
+    ram: "256Mi"
+    # -- Pod CPU request
+    cpu: "100m"
+  limit:
+    # -- Pod memory limit
+    ram: "1000Mi"
+    # -- Pod CPU limit
+    cpu: "500m"
 
 # -- Pod affinity
 affinity:

--- a/apps/stac-browser-auxip/kustomization.yaml
+++ b/apps/stac-browser-auxip/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: stac-browser
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/stac-browser-auxip/values.yaml
+++ b/apps/stac-browser-auxip/values.yaml
@@ -63,7 +63,7 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name.
   host: stac-browser-auxip.{{ platform_domain_name }}
   # -- Ingress path for the application

--- a/apps/stac-browser-cadip/kustomization.yaml
+++ b/apps/stac-browser-cadip/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: stac-browser
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/stac-browser-cadip/values.yaml
+++ b/apps/stac-browser-cadip/values.yaml
@@ -63,7 +63,7 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name.
   host: stac-browser-cadip.{{ platform_domain_name }}
   # -- Ingress path for the application

--- a/apps/stac-browser-catalog/kustomization.yaml
+++ b/apps/stac-browser-catalog/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: stac-browser
+  releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
-  version: 1.0.0-a3
   valuesFile: values.yaml
+  version: 1.0.0-a3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/stac-browser-catalog/values.yaml
+++ b/apps/stac-browser-catalog/values.yaml
@@ -61,7 +61,7 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name.
   host: stac-browser-catalog.{{ platform_domain_name }}
   # -- Ingress path for the application

--- a/apps/stac-browser-prip/kustomization.yaml
+++ b/apps/stac-browser-prip/kustomization.yaml
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commonLabels:
-  app.kubernetes.io/instance: "{{ app_name }}"
 namespace: processing
 
 helmCharts:
 - name: stac-browser
-  repo: https://rs-python.github.io/rs-helm
-  releaseName: "{{ app_name }}"
   version: 1.0.0-a3
+  releaseName: '{{ app_name }}'
+  repo: https://rs-python.github.io/rs-helm
   valuesFile: values.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/instance: '{{ app_name }}'

--- a/apps/stac-browser-prip/values.yaml
+++ b/apps/stac-browser-prip/values.yaml
@@ -63,7 +63,7 @@ ingress:
     # -- Ingress Issuer type
     type: cluster-issuer
     # -- Ingress Issuer name
-    name: letsencrypt-prod
+    name: "{{ cluster_issuer }}"
   # -- Ingress host name.
   host: stac-browser-prip.{{ platform_domain_name }}
   # -- Ingress path for the application


### PR DESCRIPTION
Followup of https://github.com/RS-PYTHON/rs-infra-core/pull/178.

Check a real deployment in Github Actions:
- initiate a matrix with and without monitoring deployment (to complete with RSPY-836)
- cache installation of conda/miniforge to speedup cicd
- allocate more disk space to minikube and free disk space on Github runner
- label the minikube node with `node-role.kubernetes.io/infra`, `node-role.kubernetes.io/rs_env`, `node-role.kubernetes.io/rs_server` and `node-role.kubernetes.io/access_csc` so that pods expected this affinity are created
- enable debug deployment to ease debugging
- fix deprecation warnings in kustomizations
- run pre-commit on all files
- deploy minio (needed for cnpg)
- configure DNS, IP and certificates properly with a local issuer instead of Let's Encrypt