### PR TITLE
RSPY-490: Allow to externalize CADIP/AUXIP collections configuration files

### DIFF
--- a/apps/rs-server-adgs/kustomization.yaml
+++ b/apps/rs-server-adgs/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
   valuesFile: values.yaml
-  version: 1.0.0-a6
+  version: 1.0.0-a6-6fea018
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/rs-server-adgs/kustomization.yaml
+++ b/apps/rs-server-adgs/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
   valuesFile: values.yaml
-  version: 1.0.0-a6-6fea018
+  version: 1.0.0-a6-194be2a
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/rs-server-adgs/values.yaml
+++ b/apps/rs-server-adgs/values.yaml
@@ -41,8 +41,8 @@ app:
   useTokenModule: false
   station:
     adgs:
-      endpoint:
-        url: {{ rs_server_station_secrets.stations.adgs.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.adgs.service.url }}
+      configFile: adgs_service_config.yaml
 
   # -- URL of the API Key Manager service
   uacURL: http://apikeymanager.processing.svc.cluster.local:8000/auth/check_key

--- a/apps/rs-server-cadip/kustomization.yaml
+++ b/apps/rs-server-cadip/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
   valuesFile: values.yaml
-  version: 1.0.0-a6-6fea018
+  version: 1.0.0-a6-194be2a
 resources:
 - grafanadatasource.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/apps/rs-server-cadip/kustomization.yaml
+++ b/apps/rs-server-cadip/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
   valuesFile: values.yaml
-  version: 1.0.0-a6
+  version: 1.0.0-a6-6fea018
 resources:
 - grafanadatasource.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/apps/rs-server-cadip/values.yaml
+++ b/apps/rs-server-cadip/values.yaml
@@ -36,30 +36,20 @@ app:
   useTokenModule: false
   station:
     mps:
-      endpoint:
-        url:
-          token: {{ rs_server_station_secrets.stations.mps.authentication.token_url }}
-          odata: {{ rs_server_station_secrets.stations.mps.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.mps.service.url }}
+      configFile: mps_service_config.yaml
     mti:
-      endpoint:
-        url:
-          token: {{ rs_server_station_secrets.stations.mti.authentication.token_url }}
-          odata: {{ rs_server_station_secrets.stations.mti.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.mti.service.url }}
+      configFile: mti_service_config.yaml
     nsg:
-      endpoint:
-        url:
-          token: {{ rs_server_station_secrets.stations.nsg.authentication.token_url }}
-          odata: {{ rs_server_station_secrets.stations.nsg.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.nsg.service.url }}
+      configFile: nsg_service_config.yaml
     sgs:
-      endpoint:
-        url:
-          token: {{ rs_server_station_secrets.stations.sgs.authentication.token_url }}
-          odata: {{ rs_server_station_secrets.stations.sgs.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.sgs.service.url }}
+      configFile: sgs_service_config.yaml
     ssc:
-      endpoint:
-        url:
-          token: {{ rs_server_station_secrets.stations.ssc.authentication.token_url }}
-          odata: {{ rs_server_station_secrets.stations.ssc.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.ssc.service.url }}
+      configFile: ssc_service_config.yaml
 
   # -- URL of the API Key Manager service
   uacURL: http://apikeymanager.processing.svc.cluster.local:8000/auth/check_key

--- a/apps/rs-server-prip/kustomization.yaml
+++ b/apps/rs-server-prip/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
   valuesFile: values.yaml
-  version: 1.0.0-a6
+  version: 1.0.0-a6-6fea018
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/rs-server-prip/kustomization.yaml
+++ b/apps/rs-server-prip/kustomization.yaml
@@ -19,7 +19,7 @@ helmCharts:
   releaseName: '{{ app_name }}'
   repo: https://rs-python.github.io/rs-helm
   valuesFile: values.yaml
-  version: 1.0.0-a6-6fea018
+  version: 1.0.0-a6-194be2a
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:

--- a/apps/rs-server-prip/values.yaml
+++ b/apps/rs-server-prip/values.yaml
@@ -40,23 +40,23 @@ app:
   useTokenModule: false
   station:
     s1a:
-      endpoint:
-        url: {{ rs_server_station_secrets.stations.s1a.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.s1a.service.url }}
+      configFile: s1a_service_config.yaml
     s1c:
-      endpoint:
-        url: {{ rs_server_station_secrets.stations.s1c.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.s1c.service.url }}
+      configFile: s1c_service_config.yaml
     s2b:
-      endpoint:
-        url: {{ rs_server_station_secrets.stations.s2b.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.s2b.service.url }}
+      configFile: s2b_service_config.yaml
     s2c:
-      endpoint:
-        url: {{ rs_server_station_secrets.stations.s2c.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.s2c.service.url }}
+      configFile: s2c_service_config.yaml
     s3a:
-      endpoint:
-        url: {{ rs_server_station_secrets.stations.s3a.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.s3a.service.url }}
+      configFile: s3a_service_config.yaml
     s3b:
-      endpoint:
-        url: {{ rs_server_station_secrets.stations.s3b.service.url }}
+      endpoint: {{ rs_server_station_secrets.stations.s3b.service.url }}
+      configFile: s3b_service_config.yaml
 
   # -- URL of the API Key Manager service
   uacURL: http://apikeymanager.processing.svc.cluster.local:8000/auth/check_key


### PR DESCRIPTION
Update of values.yaml files for CADIP, AUXIP and PRIP deployments, to reflect changes on the original hem charts.

See:
https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-490
https://github.com/RS-PYTHON/rs-helm/pull/220