### PR TITLE
Remove useless reference to object storage which is not used

### DIFF
--- a/apps/rs-server-adgs/values.yaml
+++ b/apps/rs-server-adgs/values.yaml
@@ -60,17 +60,6 @@ auth:
     # -- Random string used to encode cookie-based HTTP sessions in SessionMiddleware
     cookie_secret: "{{ rsserver_cookieSecret }}"
 
-obs:
-  # -- URL of the object storage service endpoint
-  endpoint: {{ s3.endpoint }}
-  # -- Region of the object storage service
-  region: {{ s3.region }}
-  secret:
-    # -- Access Key to authenticate with the object storage service
-    ak: {{ s3.access_key }}
-    # -- Secret Key to authenticate with the object storage service
-    sk: {{ s3.secret_key }}
-
 ingress:
   # -- Enabled/Disable ingress
   enabled: true

--- a/apps/rs-server-cadip/values.yaml
+++ b/apps/rs-server-cadip/values.yaml
@@ -67,17 +67,6 @@ auth:
     # -- Random string used to encode cookie-based HTTP sessions in SessionMiddleware
     cookie_secret: "{{ rsserver_cookieSecret }}"
 
-obs:
-  # -- URL of the object storage service endpoint
-  endpoint: {{ s3.endpoint }}
-  # -- Region of the object storage service
-  region: {{ s3.region }}
-  secret:
-    # -- Access Key to authenticate with the object storage service
-    ak: {{ s3.access_key }}
-    # -- Secret Key to authenticate with the object storage service
-    sk: {{ s3.secret_key }}
-
 ingress:
   # -- Enabled/Disable ingress
   enabled: true

--- a/apps/rs-server-edrs/values.yaml
+++ b/apps/rs-server-edrs/values.yaml
@@ -75,17 +75,6 @@ auth:
     # -- Random string used to encode cookie-based HTTP sessions in SessionMiddleware
     cookie_secret: "{{ rsserver_cookieSecret }}"
 
-obs:
-  # -- URL of the object storage service endpoint
-  endpoint: {{ s3.endpoint }}
-  # -- Region of the object storage service
-  region: {{ s3.region }}
-  secret:
-    # -- Access Key to authenticate with the object storage service
-    ak: {{ s3.access_key }}
-    # -- Secret Key to authenticate with the object storage service
-    sk: {{ s3.secret_key }}
-
 ingress:
   # -- Enabled/Disable ingress
   enabled: true

--- a/apps/rs-server-prip/values.yaml
+++ b/apps/rs-server-prip/values.yaml
@@ -74,17 +74,6 @@ auth:
     # -- Random string used to encode cookie-based HTTP sessions in SessionMiddleware
     cookie_secret: "{{ rsserver_cookieSecret }}"
 
-obs:
-  # -- URL of the object storage service endpoint
-  endpoint: {{ s3.endpoint }}
-  # -- Region of the object storage service
-  region: {{ s3.region }}
-  secret:
-    # -- Access Key to authenticate with the object storage service
-    ak: {{ s3.access_key }}
-    # -- Secret Key to authenticate with the object storage service
-    sk: {{ s3.secret_key }}
-
 ingress:
   # -- Enabled/Disable ingress
   enabled: true


### PR DESCRIPTION
Remove useless reference to object storage which is not used for:
- rs-server-adgs
- rs-server-cadip
- rs-server-prip
- rs-server-edrs