### PR TITLE
fix: no unique constraint on table

### DIFF
--- a/apps/01-cloudnative-pgstac/configmap-extensions.yaml
+++ b/apps/01-cloudnative-pgstac/configmap-extensions.yaml
@@ -42,9 +42,10 @@ data:
     psql -X -q -v ON_ERROR_STOP=1 {{ rs_server_catalog.database.name }} <<EOSQL
     SET search_path TO pgstac, public;
     INSERT INTO queryables (name)
-    VALUES
-      ('{{ queryable }}')
-    ON CONFLICT DO NOTHING;
+    SELECT '{{ queryable }}'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM queryables WHERE name = '{{ queryable }}'
+    );
     EOSQL
     {% endfor %}
 

--- a/apps/01-cloudnative-pgstac/configmap-extensions.yaml
+++ b/apps/01-cloudnative-pgstac/configmap-extensions.yaml
@@ -82,7 +82,6 @@ data:
     EOSQL
     psql -X -q -v ON_ERROR_STOP=1 {{ rs_server_catalog.database.name }} <<EOSQL
     SET search_path TO pgstac, public;
-
     INSERT INTO queryables (name, definition, property_path)
     SELECT
         'externalIds',

--- a/apps/01-cloudnative-pgstac/configmap-extensions.yaml
+++ b/apps/01-cloudnative-pgstac/configmap-extensions.yaml
@@ -82,13 +82,15 @@ data:
     EOSQL
     psql -X -q -v ON_ERROR_STOP=1 {{ rs_server_catalog.database.name }} <<EOSQL
     SET search_path TO pgstac, public;
+
     INSERT INTO queryables (name, definition, property_path)
-    VALUES (
+    SELECT
         'externalIds',
         '{"title": "externalIds", "description": "externalIds", "type": "string"}',
         'pgstac.external_ids_tokens(content->''properties''->''externalIds'')'
-    )
-    ON CONFLICT DO NOTHING;
+    WHERE NOT EXISTS (
+        SELECT 1 FROM queryables WHERE name = 'externalIds'
+    );
     EOSQL
 
 ---


### PR DESCRIPTION
As there is no unique constraint on **name** on the table **queryables**, we must perform a test before inserting or not the value, otherwise the function **queryables_constraint_triggerfunc** returns an error

```SQL
catalog=# \d queryables
                             Table "pgstac.queryables"
       Column        |  Type  | Collation | Nullable |           Default            
---------------------+--------+-----------+----------+------------------------------
 id                  | bigint |           | not null | generated always as identity
 name                | text   |           | not null | 
 collection_ids      | text[] |           |          | 
 definition          | jsonb  |           |          | 
 property_path       | text   |           |          | 
 property_wrapper    | text   |           |          | 
 property_index_type | text   |           |          | 
Indexes:
    "queryables_pkey" PRIMARY KEY, btree (id)
    "queryables_collection_idx" gin (collection_ids)
    "queryables_name_idx" btree (name)
    "queryables_property_wrapper_idx" btree (property_wrapper)
Triggers:
    queryables_constraint_insert_trigger BEFORE INSERT ON queryables FOR EACH ROW EXECUTE FUNCTION queryables_constraint_triggerfunc()
    queryables_constraint_update_trigger BEFORE UPDATE ON queryables FOR EACH ROW WHEN (new.name = old.name AND new.collection_ids IS DISTINCT FROM old.collection_ids) EXECUTE FUNCTION queryables_constraint_triggerfunc()
    queryables_trigger AFTER INSERT OR UPDATE ON queryables FOR EACH STATEMENT EXECUTE FUNCTION queryables_trigger_func()
```